### PR TITLE
Draft/606

### DIFF
--- a/3416.xml
+++ b/3416.xml
@@ -36,9 +36,9 @@
 		<Name>Outdoor lamp controller</Name>
 		<Description1>The uCIFI outdoor lamp controller object provides attributes to control, command and monitor outdoor luminaires in streets, in tunnels, on roads and for illumination of park and gardens.</Description1>
 		<ObjectID>3416</ObjectID>
-		<ObjectURN>urn:oma:lwm2m:ext:3416:3.0</ObjectURN>
+		<ObjectURN>urn:oma:lwm2m:ext:3416:4.0</ObjectURN>
 		<LWM2MVersion>1.0</LWM2MVersion>
-		<ObjectVersion>3.0</ObjectVersion>
+		<ObjectVersion>4.0</ObjectVersion>
 		<MultipleInstances>Multiple</MultipleInstances>
 		<Mandatory>Optional</Mandatory>
 		<Resources>
@@ -248,66 +248,6 @@ The following bit mask can be used to differentiate the reason of the failure:
 				<RangeEnumeration></RangeEnumeration>
 				<Units>Cel</Units>
 				<Description><![CDATA[Temperature measured by the control gear and transmitted to the device through DALI, Zhaga D4i or equivalent.]]></Description>
-			</Item>
-			<Item ID="22">
-				<Name>Control gear thermal derating</Name>
-				<Operations>R</Operations>
-				<MultipleInstances>Single</MultipleInstances>
-				<Mandatory>Optional</Mandatory>
-				<Type>Boolean</Type>
-				<RangeEnumeration></RangeEnumeration>
-				<Units></Units>
-				<Description><![CDATA[Set to True if the control gear has derated the light source due to high temperature.]]></Description>
-			</Item>
-			<Item ID="23">
-				<Name>Control gear thermal derating counter</Name>
-				<Operations>R</Operations>
-				<MultipleInstances>Single</MultipleInstances>
-				<Mandatory>Optional</Mandatory>
-				<Type>Integer</Type>
-				<RangeEnumeration></RangeEnumeration>
-				<Units></Units>
-				<Description><![CDATA[Number of time the control gear has derated the light source due to a high temperature, since last counter reset.]]></Description>
-			</Item>
-			<Item ID="24">
-				<Name>Control gear thermal derating counter reset</Name>
-				<Operations>E</Operations>
-				<MultipleInstances>Single</MultipleInstances>
-				<Mandatory>Optional</Mandatory>
-				<Type></Type>
-				<RangeEnumeration></RangeEnumeration>
-				<Units></Units>
-				<Description><![CDATA[Reset of the control gear thermal derating counter.]]></Description>
-			</Item>
-			<Item ID="25">
-				<Name>Control gear thermal shutdown</Name>
-				<Operations>R</Operations>
-				<MultipleInstances>Single</MultipleInstances>
-				<Mandatory>Optional</Mandatory>
-				<Type>Boolean</Type>
-				<RangeEnumeration></RangeEnumeration>
-				<Units></Units>
-				<Description><![CDATA[Set to True if the control gear has shut the light source down due to high temperature.]]></Description>
-			</Item>
-			<Item ID="26">
-				<Name>Control gear thermal shutdown counter</Name>
-				<Operations>R</Operations>
-				<MultipleInstances>Single</MultipleInstances>
-				<Mandatory>Optional</Mandatory>
-				<Type>Integer</Type>
-				<RangeEnumeration></RangeEnumeration>
-				<Units></Units>
-				<Description><![CDATA[Number of times the control gear has shutdown the light source since last counter reset.]]></Description>
-			</Item>
-			<Item ID="27">
-				<Name>Control gear thermal shutdown counter reset</Name>
-				<Operations>E</Operations>
-				<MultipleInstances>Single</MultipleInstances>
-				<Mandatory>Optional</Mandatory>
-				<Type></Type>
-				<RangeEnumeration></RangeEnumeration>
-				<Units></Units>
-				<Description><![CDATA[Reset of the control gear shutdown counter.]]></Description>
 			</Item>
 			<Item ID="28">
 				<Name>Output port</Name>

--- a/606.xml
+++ b/606.xml
@@ -1,0 +1,227 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- BSD-3 Clause License
+
+  Copyright 2025 Open Mobile Alliance
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions
+  are met:
+
+  1. Redistributions of source code must retain the above copyright
+  notice, this list of conditions and the following disclaimer.
+  2. Redistributions in binary form must reproduce the above copyright
+  notice, this list of conditions and the following disclaimer in the
+  documentation and/or other materials provided with the distribution.
+  3. Neither the name of the copyright holder nor the names of its
+  contributors may be used to endorse or promote products derived
+  from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+  COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+  POSSIBILITY OF SUCH DAMAGE.
+
+-->
+<LWM2M xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.openmobilealliance.org/tech/profiles/LWM2M.xsd">
+	<Object ObjectType="MODefinition">
+		<Name>DALI Diagnostic and Maintenance</Name>
+		<Description1>The OMA DALI Diagnostic and Maintenance object provides attributes read from the drivers' memory banks, regarding the matter of diagnostic and maintenan.</Description1>
+		<ObjectID>606</ObjectID>
+		<ObjectURN>urn:oma:lwm2m:oma:606</ObjectURN>
+		<LWM2MVersion>1.0</LWM2MVersion>
+		<ObjectVersion>1.0</ObjectVersion>
+		<MultipleInstances>Multiple</MultipleInstances>
+		<Mandatory>Optional</Mandatory>
+		<Resources>
+			<Item ID="1">
+				<Name>Light Source Start Counter Resettable</Name>
+				<Operations>R</Operations>
+				<MultipleInstances>Single</MultipleInstances>
+				<Mandatory>Optional</Mandatory>
+				<Type>Integer</Type>
+				<RangeEnumeration></RangeEnumeration>
+				<Units></Units>
+				<Description><![CDATA[Counts the starts of the light source.]]></Description>
+			</Item>
+			<Item ID="2">
+				<Name>Rated Median Useful Life Of Luminaire</Name>
+				<Operations>R</Operations>
+				<MultipleInstances>Single</MultipleInstances>
+				<Mandatory>Optional</Mandatory>
+				<Type>Integer</Type>
+				<RangeEnumeration></RangeEnumeration>
+				<Units>h</Units>
+				<Description><![CDATA[The parameter represents the rated median useful life time of the luminaire (including light source and other components). Scaled by a factor *1000.]]></Description>
+			</Item>
+			<Item ID="3">
+				<Name>Internal Control Gear Reference Temperature</Name>
+				<Operations>R</Operations>
+				<MultipleInstances>Single</MultipleInstances>
+				<Mandatory>Optional</Mandatory>
+				<Type>.</Type>
+				<RangeEnumeration></RangeEnumeration>
+				<Units>C</Units>
+				<Description><![CDATA[The parameter represent the internal control gear reference temperature. Offset +60°C.]]></Description>
+			</Item>
+			<Item ID="4">
+				<Name>Rated Median Useful Light Source Starts</Name>
+				<Operations>R</Operations>
+				<MultipleInstances>Single</MultipleInstances>
+				<Mandatory>Optional</Mandatory>
+				<Type>Integer</Type>
+				<RangeEnumeration></RangeEnumeration>
+				<Units></Units>
+				<Description><![CDATA[The parameter represents the rated median useful light source starts of the luminaire. Scaled by a factor *100.]]></Description>
+			</Item>
+			<Item ID="5">
+				<Name>Control Gear Output Current Percent</Name>
+				<Operations>R</Operations>
+				<MultipleInstances>Single</MultipleInstances>
+				<Mandatory>Optional</Mandatory>
+				<Type>Integer</Type>
+				<RangeEnumeration></RangeEnumeration>
+				<Units>/100</Units>
+				<Description><![CDATA[Control gear output current in % related to the nominal output current setting of the control gear.]]></Description>
+			</Item>
+			<Item ID="6">
+				<Name>Content Format ID</Name>
+				<Operations>R</Operations>
+				<MultipleInstances>Single</MultipleInstances>
+				<Mandatory>Optional</Mandatory>
+				<Type>Integer</Type>
+				<RangeEnumeration></RangeEnumeration>
+				<Units></Units>
+				<Description><![CDATA[Default 0x03.]]></Description>
+			</Item>
+			<Item ID="100">
+				<Name>Light Source Overall Failure Condition Counter</Name>
+				<Operations>R</Operations>
+				<MultipleInstances>Single</MultipleInstances>
+				<Mandatory>Optional</Mandatory>
+				<Type>Integer</Type>
+				<RangeEnumeration></RangeEnumeration>
+				<Units></Units>
+				<Description><![CDATA[Counts the number of any failure condition of the light source..]]></Description>
+			</Item>
+			<Item ID="101">
+				<Name>Light Source Short Circuit Counter</Name>
+				<Operations>R</Operations>
+				<MultipleInstances>Single</MultipleInstances>
+				<Mandatory>Optional</Mandatory>
+				<Type>Integer</Type>
+				<RangeEnumeration></RangeEnumeration>
+				<Units></Units>
+				<Description><![CDATA[Counts the number of short circuit failures of the light source.]]></Description>
+			</Item>
+			<Item ID="102">
+				<Name>Light Source Open Circuit Counter</Name>
+				<Operations>R</Operations>
+				<MultipleInstances>Single</MultipleInstances>
+				<Mandatory>Optional</Mandatory>
+				<Type>Integer</Type>
+				<RangeEnumeration></RangeEnumeration>
+				<Units></Units>
+				<Description><![CDATA[Counts the number of open circuit failures of the light source.]]></Description>
+			</Item>
+			<Item ID="103">
+				<Name>Light Source Thermal Derating Counter</Name>
+				<Operations>R</Operations>
+				<MultipleInstances>Single</MultipleInstances>
+				<Mandatory>Optional</Mandatory>
+				<Type>Integer</Type>
+				<RangeEnumeration></RangeEnumeration>
+				<Units></Units>
+				<Description><![CDATA[Counts the number of times the light source thermal’s derating was higher than the derating threshold.]]></Description>
+			</Item>
+			<Item ID="104">
+				<Name>Light Source Thermal Shutdown Counter</Name>
+				<Operations>R</Operations>
+				<MultipleInstances>Single</MultipleInstances>
+				<Mandatory>Optional</Mandatory>
+				<Type>Integer</Type>
+				<RangeEnumeration></RangeEnumeration>
+				<Units></Units>
+				<Description><![CDATA[Counts the number of times the light source’s thermal shutdown was higher than the shutdown threshold.]]></Description>
+			</Item>
+			<Item ID="200">
+				<Name>Control Gear Overall Failure Condition Counter</Name>
+				<Operations>R</Operations>
+				<MultipleInstances>Single</MultipleInstances>
+				<Mandatory>Optional</Mandatory>
+				<Type>Integer</Type>
+				<RangeEnumeration></RangeEnumeration>
+				<Units></Units>
+				<Description><![CDATA[Counts the number of any failure condition of the control gear.]]></Description>
+			</Item>
+			<Item ID="201">
+				<Name>Control Gear External Supply Undervoltage Counter</Name>
+				<Operations>R</Operations>
+				<MultipleInstances>Single</MultipleInstances>
+				<Mandatory>Optional</Mandatory>
+				<Type>Integer</Type>
+				<RangeEnumeration></RangeEnumeration>
+				<Units></Units>
+				<Description><![CDATA[Counts the number of control gear’s failures that are triggered by an undervoltage of the external supply.]]></Description>
+			</Item>
+			<Item ID="202">
+				<Name>Control Gear External Supply Overvoltage Counter</Name>
+				<Operations>R</Operations>
+				<MultipleInstances>Single</MultipleInstances>
+				<Mandatory>Optional</Mandatory>
+				<Type>Integer</Type>
+				<RangeEnumeration></RangeEnumeration>
+				<Units></Units>
+				<Description><![CDATA[Counts the number of control gear’s failures that are triggered by an overvoltage of the external supply.]]></Description>
+			</Item>
+			<Item ID="203">
+				<Name>Control Gear Output Power Limitation Counter</Name>
+				<Operations>R</Operations>
+				<MultipleInstances>Single</MultipleInstances>
+				<Mandatory>Optional</Mandatory>
+				<Type>Integer</Type>
+				<RangeEnumeration></RangeEnumeration>
+				<Units></Units>
+				<Description><![CDATA[Counts the number of control gear’s failures that are triggered when limiting of the external supply.]]></Description>
+			</Item>
+			<Item ID="204">
+				<Name>Control Gear Thermal Derating Counter</Name>
+				<Operations>R</Operations>
+				<MultipleInstances>Single</MultipleInstances>
+				<Mandatory>Optional</Mandatory>
+				<Type>Integer</Type>
+				<RangeEnumeration></RangeEnumeration>
+				<Units></Units>
+				<Description><![CDATA[Counts the number of times the control gear’s thermal derating was higher than the derating threshold.]]></Description>
+			</Item>
+			<Item ID="205">
+				<Name>Control Gear Thermal Shutdown Counter</Name>
+				<Operations>R</Operations>
+				<MultipleInstances>Single</MultipleInstances>
+				<Mandatory>Optional</Mandatory>
+				<Type>Integer</Type>
+				<RangeEnumeration></RangeEnumeration>
+				<Units></Units>
+				<Description><![CDATA[Counts the number of times the control gear’s thermal shutdown was higher than the shutdown threshold.]]></Description>
+			</Item>
+			<Item ID="5518">
+				<Name>Timestamp</Name>
+				<Operations>R</Operations>
+				<MultipleInstances>Single</MultipleInstances>
+				<Mandatory>Optional</Mandatory>
+				<Type>Time</Type>
+				<RangeEnumeration></RangeEnumeration>
+				<Units></Units>
+				<Description><![CDATA[The timestamp of when the measurement was performed.]]></Description>
+			</Item>
+		</Resources>
+		<Description2></Description2>
+	</Object>
+</LWM2M>


### PR DESCRIPTION
Created DALI Diagnostic and Maintenance object 606 to hold additional information related to various counters associated to a Control Gear or its associated lamp.

Thermal derating and shutdown status resources have been deprecated since they are already present in error flag, whilst the counter resources have been moved alongside other counters to the new DALI Diagnostic and Maintenance object

> Note:

**In making a submission to the Open Mobile Alliance Registry, you understand and agree that your submission is made under the BSD-3 Clause License as set forth on the Open Mobile Alliance Registry and that additional formats of your submission may be created by the Open Mobile Alliance tools and processes, which may convert the content of your submission, and that the Open Mobile Alliance bears no liability for the additional formats of your submission nor for any conversion of the content of your submission.**
